### PR TITLE
Restic 0.14.0 has been released

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `restic_version` | 0.10.0 | restic package version. Also accepts latest as parameter. |
+| `restic_version` | 0.14.0 | restic package version. Also accepts latest as parameter. |
 | `restic_user` | "root" | system user to run restic |
 | `restic_group` | "root" | system group to run restic |
 | `restic_shell` | "/bin/false" | the shell for the restic user, change this if you want to be able to su to it |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-restic_version: '0.10.0'
+restic_version: '0.14.0'
 
 restic_user: root
 restic_group: "{{ restic_user }}"


### PR DESCRIPTION
Restic 0.14.0 has been released a while ago.

It would be nice if the defaults and the README would reflect that. Thx!